### PR TITLE
Add Env Var setting to close the file after reading. This will fix issues in Windows

### DIFF
--- a/examples/tailunshared.rb
+++ b/examples/tailunshared.rb
@@ -2,6 +2,11 @@ require "rubygems"
 require "filewatch/tail"
 require "filewatch/buftok"
 
+# Setting  CloseAfterRead will always close the 
+# file being watched. This will allow the file
+# to be deleted in Windows.
+ENV['CloseAfterRead'] = "true"
+
 tail = FileWatch::Tail.new
 ARGV.each do |path|
   tail.tail(path)

--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -84,8 +84,13 @@ module FileWatch
         when :delete
           @logger.debug(":delete for #{path}, deleted from @files")
           _read_file(path, &block)
-          @files[path].close
-          @files.delete(path)
+		  if  @files.member?(path) 
+		    if @files[path] != nil
+				@files[path].close
+			end
+			@files.delete(path)
+		  end
+          
           @statcache.delete(path)
         else
           @logger.warn("unknown event type #{event} for #{path}")
@@ -160,7 +165,7 @@ module FileWatch
           end
 
           @sincedb[@statcache[path]] = @files[path].pos
-        rescue Errno::EWOULDBLOCK, Errno::EINTR, EOFError
+        rescue Errno::EWOULDBLOCK, Errno::EINTR, EOFError, NoMethodError
           break
         end
       end
@@ -174,6 +179,14 @@ module FileWatch
           @sincedb_last_write = now
         end
       end
+	  if ENV['CloseAfterRead'] == "true"
+		if  @files.member?(path) 
+		  if @files[path] != nil
+			@files[path].close
+		  end
+		  @files.delete(path)
+		end
+	  end
     end # def _read_file
 
     public


### PR DESCRIPTION
This commit will fix two issues in Windows when using tail.
1. If the program writing logs does not set ShareMode flags, the open operation on the file fails and messages are not written.
2. Tail is locking the log file(s) so they cannot be deleted.

In Windows if the program writing logs opens the file with dwShareMode=0
the log writing operation fails. Closing the file after reading allows
the writing process to obtain the exclusive lock.  This also allows for
rolling logs to work in windows since the file lock is released after
each read operation.
Usage:
Windows:  set CloseAfterRead=true
Ruby: ENV["CloseAfterRead"] = "true"
Mac/Linux:  Export CloseAfterRead=true