### PR TITLE
on EOF, write to sincedb

### DIFF
--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -184,8 +184,9 @@ module FileWatch
 
           @sincedb[@statcache[path]] = @files[path].pos
         rescue EOFError
-          #update sincedb on EOF, or lose position on shutdown when no writes after :sincedb_write_interval
-          _sincedb_write_if_due
+          #update sincedb on EOF
+          _sincedb_write
+	  changed = false
           break
         rescue Errno::EWOULDBLOCK, Errno::EINTR
           break
@@ -193,20 +194,15 @@ module FileWatch
       end
 
       if changed
-        _sincedb_write_if_due
+        now = Time.now.to_i
+        delta = now - @sincedb_last_write
+        if delta >= @opts[:sincedb_write_interval]
+          @logger.debug? && @logger.debug("writing sincedb (delta since last write = #{delta})")
+          _sincedb_write
+          @sincedb_last_write = now
+        end
       end
     end # def _read_file
-
-    private
-    def _sincedb_write_if_due
-      now = Time.now.to_i
-      delta = now - @sincedb_last_write
-      if delta >= @opts[:sincedb_write_interval]
-        @logger.debug? && @logger.debug("writing sincedb (delta since last write = #{delta})")
-        _sincedb_write
-        @sincedb_last_write = now
-      end
-    end # def _sincdb_write_if_due
 
     public
     def sincedb_write(reason=nil)

--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -136,7 +136,7 @@ module FileWatch
         inode = [fileId, stat.dev_major, stat.dev_minor]
       else
         inode = [stat.ino.to_s, stat.dev_major, stat.dev_minor]
-        end
+      end
   
       @statcache[path] = inode
 
@@ -183,21 +183,30 @@ module FileWatch
           end
 
           @sincedb[@statcache[path]] = @files[path].pos
-        rescue Errno::EWOULDBLOCK, Errno::EINTR, EOFError
+        rescue EOFError
+          #update sincedb on EOF, or lose position on shutdown when no writes after :sincedb_write_interval
+          _sincedb_write_if_due
+          break
+        rescue Errno::EWOULDBLOCK, Errno::EINTR
           break
         end
       end
 
       if changed
-        now = Time.now.to_i
-        delta = now - @sincedb_last_write
-        if delta >= @opts[:sincedb_write_interval]
-          @logger.debug? && @logger.debug("writing sincedb (delta since last write = #{delta})")
-          _sincedb_write
-          @sincedb_last_write = now
-        end
+        _sincedb_write_if_due
       end
     end # def _read_file
+
+    private
+    def _sincedb_write_if_due
+      now = Time.now.to_i
+      delta = now - @sincedb_last_write
+      if delta >= @opts[:sincedb_write_interval]
+        @logger.debug? && @logger.debug("writing sincedb (delta since last write = #{delta})")
+        _sincedb_write
+        @sincedb_last_write = now
+      end
+    end # def _sincdb_write_if_due
 
     public
     def sincedb_write(reason=nil)


### PR DESCRIPTION
I was expecting that if :sincedb_write_interval had passed before the tail was shut down, the sincedb would be up-to-date. In fact, up to :sincedb_write_interval worth of writes will be re-read on restart:

    #start
    echo a > log.txt
    sleep $sincedb_write_interval
    echo b > log.txt #causes _sincedb_write
    echo c > log.txt
    #wait a minute (longer than :sincedb_write_interval)
    pkill -f /usr/bin/ruby.*test.rb
    #on restart, 'c' will be re-read.

This patch checks if :sincedb_write_interval has passed if at EOF.