### PR TITLE
add option to ignore major and minor dev on inode

### DIFF
--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -33,7 +33,8 @@ module FileWatch
         :stat_interval => 1,
         :discover_interval => 5,
         :exclude => [],
-        :start_new_files_at => :end
+        :start_new_files_at => :end,
+        :ignore_inode_dev => false
       }.merge(opts)
       if !@opts.include?(:sincedb_path)
         @opts[:sincedb_path] = File.join(ENV["HOME"], ".sincedb") if ENV.include?("HOME")
@@ -114,7 +115,11 @@ module FileWatch
       end
 
       stat = File::Stat.new(path)
-      inode = [stat.ino, stat.dev_major, stat.dev_minor]
+      if @opts[:ignore_inode_dev] 
+        inode = [stat.ino, 0, 0]
+      else
+        inode = [stat.ino, stat.dev_major, stat.dev_minor]
+      end
       @statcache[path] = inode
 
       if @sincedb.member?(inode)


### PR DESCRIPTION
If you have a number of remote file systems mounted (via SMB in this case) and have a tail on a set of logs on those servers, remounting the remote file systems can cause tail to lose the position in the log, since the dev id numbers are determined at mount time. 

For example:

    stat mnt/a/1a.txt | grep Device
      Device: 2ah/42d	Inode: 6755399441239548
    stat mnt/b/1b.txt | grep Device
      Device: 29h/41d	Inode: 9317666154052854272

After remounting in a different order:

    stat mnt/a/1a.txt | grep Device
      Device: 29h/41d	Inode: 6755399441239548
    stat mnt/b/1b.txt | grep Device
      Device: 2ah/42d	Inode: 9317666154052854272

The inode id is the same though, so we can choose to ignore the device id numbers. This patch implements the option to ignore device ids.

(Eventually, I'd like to see this option exposed in the logstash 'file' input.)