### PR TITLE
Add follow_only_path flag to dumb down filewatching to just paths

### DIFF
--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -225,11 +225,7 @@ module FileWatch
       @logger.debug("_sincedb_open: reading from #{path}")
       db.each do |line|
         ino, dev_major, dev_minor, pos = line.split(" ", 4)
-		if @opts[:follow_only_path]
-			inode = [ino, dev_major.to_i, dev_minor.to_i]
-		else
-			inode = [ino.to_i, dev_major.to_i, dev_minor.to_i]
-		end
+        inode = [ino, dev_major.to_i, dev_minor.to_i]
         @logger.debug("_sincedb_open: setting #{inode.inspect} to #{pos.to_i}")
         @sincedb[inode] = pos.to_i
       end

--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -134,7 +134,14 @@ module FileWatch
         # updated files overwrite original ones, resulting in inode changes.  In order to 
         # avoid having the sincedb.member check from failing in this scenario, we'll 
         # construct the inode key using the path which will be 'stable'
-        inode = [path, stat.dev_major, stat.dev_minor]
+        #
+        # Because spaces and carriage returns are valid characters in linux paths, we have
+        # to take precautions to avoid having them show up in the .sincedb where they would
+        # derail any parsing that occurs in _sincedb_open.  Since NULL (\0) is NOT a
+        # valid path character in LINUX (one of the few), we'll replace these troublesome
+        # characters with 'encodings' that won't be encountered in a normal path but will
+        # be handled properly by __sincedb_open
+        inode = [path.gsub(/ /, "\0\0").gsub(/\n/, "\0\1"), stat.dev_major, stat.dev_minor]
       else
         if @iswindows
           fileId = Winhelper.GetWindowsUniqueFileIdentifier(path)

--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -225,7 +225,11 @@ module FileWatch
       @logger.debug("_sincedb_open: reading from #{path}")
       db.each do |line|
         ino, dev_major, dev_minor, pos = line.split(" ", 4)
-        inode = [ino, dev_major.to_i, dev_minor.to_i]
+		if @opts[:follow_only_path]
+			inode = [ino, dev_major.to_i, dev_minor.to_i]
+		else
+			inode = [ino.to_i, dev_major.to_i, dev_minor.to_i]
+		end
         @logger.debug("_sincedb_open: setting #{inode.inspect} to #{pos.to_i}")
         @sincedb[inode] = pos.to_i
       end

--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -42,7 +42,8 @@ module FileWatch
         :stat_interval => 1,
         :discover_interval => 5,
         :exclude => [],
-        :start_new_files_at => :end
+        :start_new_files_at => :end,
+        :follow_only_path => false
       }.merge(opts)
       if !@opts.include?(:sincedb_path)
         @opts[:sincedb_path] = File.join(ENV["HOME"], ".sincedb") if ENV.include?("HOME")
@@ -128,13 +129,22 @@ module FileWatch
 
       stat = File::Stat.new(path)
       
-      if @iswindows
-        fileId = Winhelper.GetWindowsUniqueFileIdentifier(path)
-        inode = [fileId, stat.dev_major, stat.dev_minor]
+      if @opts[:follow_only_path]
+        # In cases where files are rsynced to the consuming server, inodes will change when 
+        # updated files overwrite original ones, resulting in inode changes.  In order to 
+        # avoid having the sincedb.member check from failing in this scenario, we'll 
+        # construct the inode key using the path which will be 'stable'
+        inode = [path, stat.dev_major, stat.dev_minor]
       else
-        inode = [stat.ino.to_s, stat.dev_major, stat.dev_minor]
+        if @iswindows
+          fileId = Winhelper.GetWindowsUniqueFileIdentifier(path)
+          inode = [fileId, stat.dev_major, stat.dev_minor]
+        else
+          inode = [stat.ino.to_s, stat.dev_major, stat.dev_minor]
         end
-  
+      end
+
+ 
       @statcache[path] = inode
 
       if @sincedb.member?(inode)


### PR DESCRIPTION
I'm putting together a Logstash deployment which involves a number of production servers regularly rsync'ing files to a central log repository. When running Logstash from this central server, it appears that the filewatch code behind the Logstash 'file' input is detecting the updated inode on each rsync and treating the file as new.

The changes here allow a 'follow_only_path' flag to be specified that causes the inode variable to be constructed from the file path rather than the file's inode.  This allows the inode variable to remain the same after an rsync updates the file's inode, allowing the @sincedb lookup to file the same entry and continue parsing the file from where it left off
