### PR TITLE
Closing existing sincedb in sincedb_open

### DIFF
--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -208,6 +208,7 @@ module FileWatch
       begin
         db = File.open(path)
       rescue
+        #No existing sincedb to load
         @logger.debug("_sincedb_open: #{path}: #{$!}")
         return
       end
@@ -219,6 +220,7 @@ module FileWatch
         @logger.debug("_sincedb_open: setting #{inode.inspect} to #{pos.to_i}")
         @sincedb[inode] = pos.to_i
       end
+      db.close
     end # def _sincedb_open
 
     private


### PR DESCRIPTION
When an existing sincedb exists it is read at startup, but changes cannot be written as the file handler was not closed.