### PR TITLE
[WINDOWS] Error when a file is deleted

### DIFF
--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -93,8 +93,10 @@ module FileWatch
           end
         when :delete
           @logger.debug? && @logger.debug(":delete for #{path}, deleted from @files")
-          _read_file(path, &block)
-          @files[path].close
+          if @files[path]
+            _read_file(path, &block)
+            @files[path].close
+          end
           @files.delete(path)
           @statcache.delete(path)
         else

--- a/spec/tail_spec.rb
+++ b/spec/tail_spec.rb
@@ -3,7 +3,7 @@ require 'stud/temporary'
 
 describe FileWatch::Tail do
 
-  let(:file_path) { Stud::Temporary.file.path }
+  let(:file_path) { f = Stud::Temporary.file ; f.close; f.path }
   let(:sincedb_path) { Stud::Temporary.file.path }
 
   before :each do
@@ -35,6 +35,21 @@ describe FileWatch::Tail do
 
     it "reads new lines off the file" do
       expect { |b| subject.subscribe(&b) }.to yield_successive_args([file_path, "line1"], [file_path, "line2"])
+    end
+  end
+
+  context "when a file is deleted" do
+    subject { FileWatch::Tail.new(:sincedb_path => sincedb_path, :start_new_files_at => :beginning) }
+
+    before :each do
+      File.open(file_path, "w") { |file|  file.write("line1\nline2\n") }
+      subject.tail(file_path)
+      File.unlink file_path
+    end
+
+    it "should not raise exception" do
+      Thread.new(subject) { sleep 0.1; subject.quit } # force the subscribe loop to exit
+      expect { subject.subscribe {|p,l| } }.to_not raise_exception
     end
   end
 end


### PR DESCRIPTION
Ì suppose the file handler is shared on windows it is "magically" set to nil as soon as the file is deleted
Add a check for existence to havoid to read from Nil

````
NoMethodError: undefined method `sysread' for nil:NilClass
  _read_file at D:/dev/wiibaa/ruby-filewatch/lib/filewatch/tail.rb:176
        loop at org/jruby/RubyKernel.java:1507
  _read_file at D:/dev/wiibaa/ruby-filewatch/lib/filewatch/tail.rb:174
   subscribe at D:/dev/wiibaa/ruby-filewatch/lib/filewatch/tail.rb:95
        each at D:/dev/wiibaa/ruby-filewatch/lib/filewatch/watch.rb:72
        each at org/jruby/RubyArray.java:1613
        each at D:/dev/wiibaa/ruby-filewatch/lib/filewatch/watch.rb:65
   subscribe at D:/dev/wiibaa/ruby-filewatch/lib/filewatch/watch.rb:113
   subscribe at D:/dev/wiibaa/ruby-filewatch/lib/filewatch/tail.rb:73
      (root) at tail.rb:21
````