### PR TITLE
Explicitly close file opened in _sincedb_open

### DIFF
--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -219,6 +219,7 @@ module FileWatch
         @logger.debug("_sincedb_open: setting #{inode.inspect} to #{pos.to_i}")
         @sincedb[inode] = pos.to_i
       end
+      db.close
     end # def _sincedb_open
 
     private


### PR DESCRIPTION
_sincedb_open doesn't close the file it opens. That created a problem when running on Windows/JRuby, where _sincedb_write wouldn't update and existing sincedb file.