### PR TITLE
expose delimiter in FileWatch::Tail.new

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+group :test do
+  gem 'rspec'
+  gem 'stud'
+end

--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -42,7 +42,8 @@ module FileWatch
         :stat_interval => 1,
         :discover_interval => 5,
         :exclude => [],
-        :start_new_files_at => :end
+        :start_new_files_at => :end,
+        :delimiter => "\n"
       }.merge(opts)
       if !@opts.include?(:sincedb_path)
         @opts[:sincedb_path] = File.join(ENV["HOME"], ".sincedb") if ENV.include?("HOME")
@@ -168,7 +169,7 @@ module FileWatch
 
     private
     def _read_file(path, &block)
-      @buffers[path] ||= FileWatch::BufferedTokenizer.new
+      @buffers[path] ||= FileWatch::BufferedTokenizer.new(@opts[:delimiter])
 
       changed = false
       loop do

--- a/spec/buftok_spec.rb
+++ b/spec/buftok_spec.rb
@@ -1,0 +1,22 @@
+require 'filewatch/buftok'
+
+describe FileWatch::BufferedTokenizer do
+
+  context "when using the default delimiter" do
+    subject { FileWatch::BufferedTokenizer.new }
+
+    it "splits the lines correctly" do
+      message = "hello\nworld\n"
+      expect(subject.extract(message)).to eq ["hello", "world"]
+    end
+  end
+
+  context "when passing a custom delimiter" do
+    subject { FileWatch::BufferedTokenizer.new("\r\n") }
+
+    it "splits the lines correctly" do
+      message = "hello\r\nworld\r\n"
+      expect(subject.extract(message)).to eq ["hello", "world"]
+    end
+  end
+end

--- a/spec/tail_spec.rb
+++ b/spec/tail_spec.rb
@@ -1,0 +1,39 @@
+require 'filewatch/tail'
+require 'stud/temporary'
+
+describe FileWatch::Tail do
+
+  let(:file_path) { Stud::Temporary.file.path }
+  let(:sincedb_path) { Stud::Temporary.file.path }
+
+  context "when watching a file" do
+    subject { FileWatch::Tail.new(:sincedb_path => sincedb_path, :start_new_files_at => :beginning) }
+
+    before :each do
+      File.open(file_path, "w") { |file|  file.write("line1\nline2\n") }
+      subject.tail(file_path)
+    end
+
+    it "reads new lines off the file" do
+      Thread.new(subject) { sleep 0.1; subject.quit } # force the subscribe loop to exit
+      expect { |b| subject.subscribe(&b) }.to yield_successive_args([file_path, "line1"], [file_path, "line2"])
+    end
+  end
+
+  context "when watching a CRLF file" do
+    subject { FileWatch::Tail.new(:sincedb_path => sincedb_path,
+                                  :start_new_files_at => :beginning,
+                                  :delimiter => "\r\n") }
+
+    before :each do
+      File.open(file_path, "w") { |file|  file.write("line1\r\nline2\r\n") }
+      subject.tail(file_path)
+    end
+
+    it "reads new lines off the file" do
+      Thread.new(subject) { sleep 0.1; subject.quit } # force the subscribe loop to exit
+      expect { |b| subject.subscribe(&b) }.to yield_successive_args([file_path, "line1"], [file_path, "line2"])
+    end
+  end
+end
+


### PR DESCRIPTION
Proper fix for CRLF file support, replaces #46 