### PR TITLE
Clean-up watch inode vs tail sincedb identifier usage + first test on writing sincedb

### DIFF
--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -248,6 +248,7 @@ module FileWatch
 
     public
     def quit
+      _sincedb_write
       @watch.quit
     end # def quit
   end # class Tail

--- a/spec/tail_spec.rb
+++ b/spec/tail_spec.rb
@@ -70,9 +70,9 @@ describe FileWatch::Tail do
       #restart
       File.open(file_path, "ab") { |file|  file.write("line3\nline4\n") }
       subject.tail(file_path)
-      Thread.new(subject) { sleep 0.5; subject.sincedb_write; subject.quit }
+      Thread.new(subject) { sleep 0.5; subject.quit }
       expect { |b| subject.subscribe(&b) }.to yield_successive_args([file_path, "line3"], [file_path, "line4"])
-      #SinceDB is written at exit as requested
+      #SinceDB is written at exit
       sleep 1
       stat = File::Stat.new(file_path)
       sincedb_id = subject.sincedb_record_uid(file_path,stat).join(' ')

--- a/spec/tail_spec.rb
+++ b/spec/tail_spec.rb
@@ -53,7 +53,7 @@ describe FileWatch::Tail do
     end
   end
 
-  context "when writting sincedb" do
+  describe "sincedb" do
     subject { FileWatch::Tail.new(:sincedb_path => sincedb_path, :start_new_files_at => :beginning, :stat_interval => 0) }
 
     before :each do
@@ -61,22 +61,35 @@ describe FileWatch::Tail do
       subject.tail(file_path)
     end
 
-    it "reads new lines off the file" do
-      expect { |b| subject.subscribe(&b) }.to yield_successive_args([file_path, "line1"], [file_path, "line2"])
-      #SinceDB is written after first read
-      stat = File::Stat.new(file_path)
-      sincedb_id = subject.sincedb_record_uid(file_path,stat).join(' ')
-      expect(File.read(sincedb_path)).to eq("#{sincedb_id} #{stat.size}\n")
-      #restart
-      File.open(file_path, "ab") { |file|  file.write("line3\nline4\n") }
-      subject.tail(file_path)
-      Thread.new(subject) { sleep 0.5; subject.quit }
-      expect { |b| subject.subscribe(&b) }.to yield_successive_args([file_path, "line3"], [file_path, "line4"])
-      #SinceDB is written at exit
-      sleep 1
-      stat = File::Stat.new(file_path)
-      sincedb_id = subject.sincedb_record_uid(file_path,stat).join(' ')
-      expect(File.read(sincedb_path)).to eq("#{sincedb_id} #{stat.size}\n")
+    context "when reading a new file" do
+      it "updates sincedb after subscribe" do
+        subject.subscribe {|_,_|  }
+        stat = File::Stat.new(file_path)
+        sincedb_id = subject.sincedb_record_uid(file_path,stat).join(' ')
+        expect(File.read(sincedb_path)).to eq("#{sincedb_id} #{stat.size}\n")
+      end
+    end
+
+    context "when restarting tail" do
+
+      before :each do
+        subject.subscribe {|_,_| }
+        sleep 0.6 # wait for tail.quit
+        subject.tail(file_path) # re-tail file
+        File.open(file_path, "ab") { |file| file.write("line3\nline4\n") }
+        Thread.new(subject) { sleep 0.5; subject.quit }
+      end
+
+      it "picks off from where it stopped" do
+        expect { |b| subject.subscribe(&b) }.to yield_successive_args([file_path, "line3"], [file_path, "line4"])
+      end
+
+      it "updates on tail.quit" do
+        subject.subscribe {|_,_| }
+        stat = File::Stat.new(file_path)
+        sincedb_id = subject.sincedb_record_uid(file_path,stat).join(' ')
+        expect(File.read(sincedb_path)).to eq("#{sincedb_id} #{stat.size}\n")
+      end
     end
   end
 end


### PR DESCRIPTION
DRY the creation of **inode** used for watching a path.
Also make a clear distinction in var names as the format of the sincedb may evolves differently from the **inode** used in watch (see existing PR related to using path only, skipping dev_minor etc etc)