### PR TITLE
sincedb: do not read entire line

### DIFF
--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -99,7 +99,7 @@ module FileWatch
           end
           @files.delete(path)
           inode = @statcache.delete(path)
-          @sincedb[inode] = 0
+          @sincedb.delete(inode)
         else
           @logger.warn("unknown event type #{event} for #{path}")
         end

--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -98,7 +98,8 @@ module FileWatch
             @files[path].close
           end
           @files.delete(path)
-          @statcache.delete(path)
+          inode = @statcache.delete(path)
+          @sincedb[inode] = 0
         else
           @logger.warn("unknown event type #{event} for #{path}")
         end


### PR DESCRIPTION
The issue occurs when we delete a file and then add a new one -- even if it has a different name -- it may well have the same inode number, and the File handler will think it is the same file. In this case we should reset the position to 0 (the old inode)