### PR TITLE
support device files in _sincedb_write and improve atomic file write

### DIFF
--- a/lib/filewatch/helper.rb
+++ b/lib/filewatch/helper.rb
@@ -62,4 +62,8 @@ class File
   def self.rand_filename(prefix)
     [ prefix, Thread.current.object_id, Process.pid, rand(1000000) ].join('.')
   end
+
+  def self.device?(file_name)
+    chardev?(file_name) || blockdev?(file_name)
+  end
 end

--- a/lib/filewatch/helper.rb
+++ b/lib/filewatch/helper.rb
@@ -56,7 +56,7 @@ class File
   rescue
     # ...
   ensure
-    FileUtils.rm_f(file_name) if file_name
+    FileUtils.rm_f(file_name) if File.exist?(file_name)
   end
 
   def self.rand_filename(prefix)

--- a/lib/filewatch/helper.rb
+++ b/lib/filewatch/helper.rb
@@ -1,0 +1,73 @@
+# code downloaded from Ruby on Rails 4.2.1
+# https://raw.githubusercontent.com/rails/rails/v4.2.1/activesupport/lib/active_support/core_ext/file/atomic.rb
+require 'fileutils'
+
+class File
+  # Write to a file atomically. Useful for situations where you don't
+  # want other processes or threads to see half-written files.
+  #
+  #   File.atomic_write('important.file') do |file|
+  #     file.write('hello')
+  #   end
+  #
+  # If your temp directory is not on the same filesystem as the file you're
+  # trying to write, you can provide a different temporary directory.
+  #
+  #   File.atomic_write('/data/something.important', '/data/tmp') do |file|
+  #     file.write('hello')
+  #   end
+  def self.atomic_write(file_name, temp_dir = Dir.tmpdir)
+    require 'tempfile' unless defined?(Tempfile)
+    require 'fileutils' unless defined?(FileUtils)
+
+    temp_file = Tempfile.new(basename(file_name), temp_dir)
+    temp_file.binmode
+    return_val = yield temp_file
+    temp_file.close
+
+    if File.exist?(file_name)
+      # Get original file permissions
+      old_stat = stat(file_name)
+    else
+      # If not possible, probe which are the default permissions in the
+      # destination directory.
+      old_stat = probe_stat_in(dirname(file_name))
+    end
+
+    # Overwrite original file with temp file
+    FileUtils.mv(temp_file.path, file_name)
+
+    # Unable to get permissions of the original file => return
+    return return_val if old_stat.nil?
+
+    # Set correct permissions on new file
+    begin
+      chown(old_stat.uid, old_stat.gid, file_name)
+      # This operation will affect filesystem ACL's
+      chmod(old_stat.mode, file_name)
+
+      # Make sure we return the result of the yielded block
+      return_val
+    rescue Errno::EPERM, Errno::EACCES
+      # Changing file ownership failed, moving on.
+    end
+  end
+
+  # Private utility method.
+  def self.probe_stat_in(dir) #:nodoc:
+    basename = [
+      '.permissions_check',
+      Thread.current.object_id,
+      Process.pid,
+      rand(1000000)
+    ].join('.')
+
+    file_name = join(dir, basename)
+    FileUtils.touch(file_name)
+    stat(file_name)
+  rescue
+    # ...
+  ensure
+    FileUtils.rm_f(file_name) if file_name
+  end
+end

--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -1,3 +1,4 @@
+require "filewatch/helper"
 require "filewatch/buftok"
 require "filewatch/watch"
 if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
@@ -226,23 +227,11 @@ module FileWatch
     private
     def _sincedb_write
       path = @opts[:sincedb_path]
-      tmp = "#{path}.new"
-      begin
-        db = File.open(tmp, "w")
-      rescue => e
-        @logger.warn("_sincedb_write failed: #{tmp}: #{e}")
-        return
-      end
-
-      @sincedb.each do |sincedb_record_uid, pos|
-        db.puts([sincedb_record_uid, pos].flatten.join(" "))
-      end
-      db.close
-
-      begin
-        File.rename(tmp, path)
-      rescue => e
-        @logger.warn("_sincedb_write rename/sync failed: #{tmp} -> #{path}: #{e}")
+      return if path == "/dev/null"
+      File.atomic_write(path) do |file|
+        @sincedb.each do |inode, pos|
+          file.puts([inode, pos].flatten.join(" "))
+        end
       end
     end # def _sincedb_write
 


### PR DESCRIPTION
Currently, in order to prevent sincedb corruption during _sincedb_write, the new sincedb state is written in a temporary file in the same path as sincedb, then replaced. However this fails in certain situations:

a) sincedb_path can point to "/dev/null". replacing it will result in a permission denied
b) the sincedb file can be in a directory where the user cannot write to, only modify that single file.

Solution: 
a) skip sincedb_write if sincedb_path is "/dev/null"
b) write the temporary file in Dir.tmpdir, then move the file

This uses File#atomic_write implementation extracted from Ruby on Rails, with some modifications

addresses https://github.com/elastic/logstash/issues/2964, https://github.com/elastic/logstash/issues/2935, https://github.com/elastic/logstash/issues/2882, https://github.com/logstash-plugins/logstash-input-file/issues/16