### PR TITLE
sort discovered files by date modified

### DIFF
--- a/lib/filewatch/watch.rb
+++ b/lib/filewatch/watch.rb
@@ -128,7 +128,7 @@ module FileWatch
 
     private
     def _discover_file(path, initial=false)
-      globbed_dirs = Dir.glob(path)
+      globbed_dirs = Dir.glob(path).sort_by { |a| File.mtime(a) }
       @logger.debug? && @logger.debug("_discover_file_glob: #{path}: glob is: #{globbed_dirs}")
       if globbed_dirs.empty? && File.file?(path)
         globbed_dirs = [path]


### PR DESCRIPTION
for people doing bulk import it's important to know which files are going to be processed.
Ultimately a better patch is to pass how to sort (date modified, alphabetically, none - in this case the user should rely on the fact that Dir.glob behaves differently across platforms) and logstash e.g. the file plugin could have option "sort". 

for now I think it's important users KNOW that files are sorted by date modified or alternatively alphabetically: 
```globbed_dirs = Dir.glob(path).sort```