### PR TITLE
use xattr to trace file instead of inode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,6 @@ source "https://rubygems.org"
 group :test do
   gem 'rspec'
   gem 'stud', "~> 0.0.18"
+  gem 'uuid', "~> 2.3.8"
+  gem 'ffi-xattr', "~> 0.1.2"
 end

--- a/lib/filewatch/watch.rb
+++ b/lib/filewatch/watch.rb
@@ -52,17 +52,21 @@ module FileWatch
         fileId = Winhelper.GetWindowsUniqueFileIdentifier(path)
         inode = [fileId, stat.dev_major, stat.dev_minor]
       elsif @xattr
-        xattr = Xattr.new(path)
+        begin
+          xattr = Xattr.new(path)
 
-        fileId = xattr[@xattr]
+          fileId = xattr[@xattr]
 
-        if !fileId
-          fileId = @uuid.generate
+          if !fileId
+            fileId = @uuid.generate
 
-          xattr[@xattr] = fileId
+            xattr[@xattr] = fileId
+          end
+
+          inode = [fileId, stat.dev_major, stat.dev_minor]
+        rescue
+          inode = [stat.ino.to_s, stat.dev_major, stat.dev_minor]
         end
-
-        inode = [fileId, stat.dev_major, stat.dev_minor]
       else
         inode = [stat.ino.to_s, stat.dev_major, stat.dev_minor]
       end

--- a/lib/filewatch/watch.rb
+++ b/lib/filewatch/watch.rb
@@ -2,6 +2,8 @@ require "logger"
 if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
   require "filewatch/winhelper"
 end
+require "ffi-xattr"
+require "uuid"
 
 module FileWatch
   class Watch
@@ -19,6 +21,9 @@ module FileWatch
       @watching = []
       @exclude = []
       @files = Hash.new { |h, k| h[k] = Hash.new }
+
+      @xattr = opts[:xattr] || 'uuid'
+      @uuid = UUID.new if @xattr
     end # def initialize
 
     public
@@ -45,6 +50,18 @@ module FileWatch
     def inode(path,stat)
       if @iswindows
         fileId = Winhelper.GetWindowsUniqueFileIdentifier(path)
+        inode = [fileId, stat.dev_major, stat.dev_minor]
+      elsif @xattr
+        xattr = Xattr.new(path)
+
+        fileId = xattr[@xattr]
+
+        if !fileId
+          fileId = @uuid.generate
+
+          xattr[@xattr] = fileId
+        end
+
         inode = [fileId, stat.dev_major, stat.dev_minor]
       else
         inode = [stat.ino.to_s, stat.dev_major, stat.dev_minor]

--- a/spec/tail_spec.rb
+++ b/spec/tail_spec.rb
@@ -1,5 +1,6 @@
 require 'filewatch/tail'
 require 'stud/temporary'
+require 'ffi-xattr'
 
 describe FileWatch::Tail do
 
@@ -20,6 +21,14 @@ describe FileWatch::Tail do
 
     it "reads new lines off the file" do
       expect { |b| subject.subscribe(&b) }.to yield_successive_args([file_path, "line1"], [file_path, "line2"])
+    end
+
+    it "file contains xattr 'uuid'" do
+      subject.subscribe {|_,_|  }
+      stat = File::Stat.new(file_path)
+      sincedb_id = subject.sincedb_record_uid(file_path,stat)[0]
+
+      expect(Xattr.new(file_path)['uuid']).to eq(sincedb_id)
     end
   end
 


### PR DESCRIPTION
When we trace file with inode, it will confuse sincedb if filesystem reuse an inode, which cause the file truncated random

https://logstash.jira.com/browse/LOGSTASH-685

Since we hard to prevent filesystem reuse a inode, we could use another fileId like windows did

http://stackoverflow.com/questions/16069898/can-inode-and-crtime-be-used-as-a-unique-file-identifier 

As you know, most modern filesystem support `Extended File Attributes`, we could generate a UUID for file and store it in xattrs, which will associated with inodes (files,  directories,  symlinks,  etc).

https://en.wikipedia.org/wiki/Extended_file_attributes
http://manpages.ubuntu.com/manpages/precise/man2/getxattr.2.html