### PR TITLE
Change how we handle the FileTime inside the FileInformation Struct

### DIFF
--- a/filewatch.gemspec
+++ b/filewatch.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.name = "filewatch"
-  spec.version = "0.6.5"
+  spec.version = "0.6.6"
   spec.summary = "filewatch - file watching for ruby"
   spec.description = "Watch files and directories in ruby. Also supports tailing and glob file patterns."
   spec.files = files
@@ -18,5 +18,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Jordan Sissel", "Pete Fritchman"]
   spec.email = ["jls@semicomplete.com", "petef@databits.net"]
   spec.homepage = "https://github.com/jordansissel/ruby-filewatch"
+
+  spec.add_development_dependency "stud"
 end
 

--- a/lib/filewatch/winhelper.rb
+++ b/lib/filewatch/winhelper.rb
@@ -12,12 +12,6 @@ module Winhelper
 	
 	#http://msdn.microsoft.com/en-us/library/windows/desktop/aa363788(v=vs.85).aspx
 	class FileInformation < FFI::Struct
-		def initialize()
-			createTime = FileTime.new
-			lastAccessTime = FileTime.new
-			lastWriteTime = FileTime.new
-		end
-		
 		layout :fileAttributes, :uint, #DWORD    dwFileAttributes;
 		:createTime, FileTime,  #FILETIME ftCreationTime;
 		:lastAccessTime, FileTime, #FILETIME ftLastAccessTime;
@@ -56,7 +50,7 @@ module Winhelper
 			#	]
 			#p "Information: %u %u %u %u %u %u %u " % args
 			#this is only guaranteed on NTFS, for ReFS on windows 2012, GetFileInformationByHandleEx should be used with FILE_ID_INFO, which returns a 128 bit identifier
-			return "#{fileInfo[:volumeSerialNumber]}-#{fileInfo[:fileIndexLow]}-#{fileInfo[:fileIndexHigh]}"
+      return "#{fileInfo[:volumeSerialNumber]}-#{fileInfo[:fileIndexLow]}-#{fileInfo[:fileIndexHigh]}"
 		else
 			#p "cannot retrieve file information, returning path"
 			return path;

--- a/lib/filewatch/winhelper.rb
+++ b/lib/filewatch/winhelper.rb
@@ -1,61 +1,61 @@
 require "ffi"
-	
+
 module Winhelper
-	extend FFI::Library
-	
-	ffi_lib 'kernel32'
-	ffi_convention :stdcall
-	class FileTime < FFI::Struct
-		layout :lowDateTime, :uint,
-		:highDateTime, :uint
-	end
-	
-	#http://msdn.microsoft.com/en-us/library/windows/desktop/aa363788(v=vs.85).aspx
-	class FileInformation < FFI::Struct
-		layout :fileAttributes, :uint, #DWORD    dwFileAttributes;
-		:createTime, FileTime,  #FILETIME ftCreationTime;
-		:lastAccessTime, FileTime, #FILETIME ftLastAccessTime;
-		:lastWriteTime, FileTime, #FILETIME ftLastWriteTime;
-		:volumeSerialNumber, :uint, #DWORD    dwVolumeSerialNumber;
-		:fileSizeHigh, :uint, #DWORD    nFileSizeHigh;
-		:fileSizeLow, :uint, #DWORD    nFileSizeLow;
-		:numberOfLinks, :uint, #DWORD    nNumberOfLinks;
-		:fileIndexHigh, :uint, #DWORD    nFileIndexHigh;
-		:fileIndexLow, :uint #DWORD    nFileIndexLow;
-	end
-		
-	
-	#http://msdn.microsoft.com/en-us/library/windows/desktop/aa363858(v=vs.85).aspx
-	#HANDLE WINAPI CreateFile(_In_ LPCTSTR lpFileName,_In_  DWORD dwDesiredAccess,_In_ DWORD dwShareMode,
-	#						_In_opt_  LPSECURITY_ATTRIBUTES lpSecurityAttributes,_In_  DWORD dwCreationDisposition,
-	#						_In_      DWORD dwFlagsAndAttributes,_In_opt_  HANDLE hTemplateFile);
-	attach_function :GetOpenFileHandle, :CreateFileA, [:pointer, :uint, :uint, :pointer, :uint, :uint, :pointer], :pointer	
-	
-	#http://msdn.microsoft.com/en-us/library/windows/desktop/aa364952(v=vs.85).aspx
-	#BOOL WINAPI GetFileInformationByHandle(_In_   HANDLE hFile,_Out_  LPBY_HANDLE_FILE_INFORMATION lpFileInformation);
-	attach_function :GetFileInformationByHandle, [:pointer, :pointer], :int
-	
-	attach_function :CloseHandle, [:pointer], :int
-	
-	
-	def self.GetWindowsUniqueFileIdentifier(path)
-		handle = GetOpenFileHandle(path, 0, 7, nil, 3, 128, nil)
-		fileInfo = Winhelper::FileInformation.new
-		success = GetFileInformationByHandle(handle, fileInfo)
-		CloseHandle(handle)
-		if  success == 1
-			#args = [
-			#		fileInfo[:fileAttributes], fileInfo[:volumeSerialNumber], fileInfo[:fileSizeHigh], fileInfo[:fileSizeLow], 
-			#		fileInfo[:numberOfLinks], fileInfo[:fileIndexHigh], fileInfo[:fileIndexLow]
-			#	]
-			#p "Information: %u %u %u %u %u %u %u " % args
-			#this is only guaranteed on NTFS, for ReFS on windows 2012, GetFileInformationByHandleEx should be used with FILE_ID_INFO, which returns a 128 bit identifier
+  extend FFI::Library
+
+  ffi_lib 'kernel32'
+  ffi_convention :stdcall
+  class FileTime < FFI::Struct
+    layout :lowDateTime, :uint,
+      :highDateTime, :uint
+  end
+
+  #http://msdn.microsoft.com/en-us/library/windows/desktop/aa363788(v=vs.85).aspx
+  class FileInformation < FFI::Struct
+    layout :fileAttributes, :uint, #DWORD    dwFileAttributes;
+      :createTime, FileTime,  #FILETIME ftCreationTime;
+      :lastAccessTime, FileTime, #FILETIME ftLastAccessTime;
+      :lastWriteTime, FileTime, #FILETIME ftLastWriteTime;
+      :volumeSerialNumber, :uint, #DWORD    dwVolumeSerialNumber;
+      :fileSizeHigh, :uint, #DWORD    nFileSizeHigh;
+      :fileSizeLow, :uint, #DWORD    nFileSizeLow;
+      :numberOfLinks, :uint, #DWORD    nNumberOfLinks;
+      :fileIndexHigh, :uint, #DWORD    nFileIndexHigh;
+      :fileIndexLow, :uint #DWORD    nFileIndexLow;
+  end
+
+
+  #http://msdn.microsoft.com/en-us/library/windows/desktop/aa363858(v=vs.85).aspx
+  #HANDLE WINAPI CreateFile(_In_ LPCTSTR lpFileName,_In_  DWORD dwDesiredAccess,_In_ DWORD dwShareMode,
+  #						_In_opt_  LPSECURITY_ATTRIBUTES lpSecurityAttributes,_In_  DWORD dwCreationDisposition,
+  #						_In_      DWORD dwFlagsAndAttributes,_In_opt_  HANDLE hTemplateFile);
+  attach_function :GetOpenFileHandle, :CreateFileA, [:pointer, :uint, :uint, :pointer, :uint, :uint, :pointer], :pointer	
+
+  #http://msdn.microsoft.com/en-us/library/windows/desktop/aa364952(v=vs.85).aspx
+  #BOOL WINAPI GetFileInformationByHandle(_In_   HANDLE hFile,_Out_  LPBY_HANDLE_FILE_INFORMATION lpFileInformation);
+  attach_function :GetFileInformationByHandle, [:pointer, :pointer], :int
+
+  attach_function :CloseHandle, [:pointer], :int
+
+
+  def self.GetWindowsUniqueFileIdentifier(path)
+    handle = GetOpenFileHandle(path, 0, 7, nil, 3, 128, nil)
+    fileInfo = Winhelper::FileInformation.new
+    success = GetFileInformationByHandle(handle, fileInfo)
+    CloseHandle(handle)
+    if  success == 1
+      #args = [
+      #		fileInfo[:fileAttributes], fileInfo[:volumeSerialNumber], fileInfo[:fileSizeHigh], fileInfo[:fileSizeLow], 
+      #		fileInfo[:numberOfLinks], fileInfo[:fileIndexHigh], fileInfo[:fileIndexLow]
+      #	]
+      #p "Information: %u %u %u %u %u %u %u " % args
+      #this is only guaranteed on NTFS, for ReFS on windows 2012, GetFileInformationByHandleEx should be used with FILE_ID_INFO, which returns a 128 bit identifier
       return "#{fileInfo[:volumeSerialNumber]}-#{fileInfo[:fileIndexLow]}-#{fileInfo[:fileIndexHigh]}"
-		else
-			#p "cannot retrieve file information, returning path"
-			return path;
-		end
-	end
+    else
+      #p "cannot retrieve file information, returning path"
+      return path;
+    end
+  end
 end
 
 #fileId = Winhelper.GetWindowsUniqueFileIdentifier('C:\inetpub\logs\LogFiles\W3SVC1\u_ex1fdsadfsadfasdf30612.log')

--- a/spec/winhelper_spec.rb
+++ b/spec/winhelper_spec.rb
@@ -5,7 +5,7 @@ if Gem.win_platform?
   require "lib/filewatch/winhelper"
 
   describe Winhelper do
-    let(:path) { Stud::Temporare.file }
+    let(:path) { Stud::Temporary.file.path }
 
     after do
       FileUtils.rm_rf(path)

--- a/spec/winhelper_spec.rb
+++ b/spec/winhelper_spec.rb
@@ -1,0 +1,22 @@
+require "stud/temporary"
+require "fileutils"
+
+if Gem.win_platform?
+  require "lib/filewatch/winhelper"
+
+  describe Winhelper do
+    let(:path) { Stud::Temporare.file }
+
+    after do
+      FileUtils.rm_rf(path)
+    end
+
+    it "return a unique file identifier" do
+      volume_serial, file_index_low, file_index_high = Winhelper.GetWindowsUniqueFileIdentifier(path).split("").map(&:to_i)
+
+      expect(volume_serial).not_to eq(0)
+      expect(file_index_low).not_to eq(0)
+      expect(file_index_high).not_to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Instead of instancing 3 local variable in the initialize method
which never be use, we rely on FFI to correctly instantiate them.

This change has a side effect of reducing the memory on the Heap to keep
track of the native memory and make the garbage collector work a bit
smoother on the values.

Compare performance using this code with the previous version and using visualvm.

```ruby
40_000_000.times do
 fileId = Winhelper.GetWindowsUniqueFileIdentifier('C:\sample_logs')
end
```

The allocation done in the initialize method wasn't necessary but required to allocate more instances of the `org.jruby.ext.ffi.jffi.CachingNativeMemoryAllocator$MemoryAllocation `.

Without the changes: 
![screenshot 2015-10-27 15 53 47](https://cloud.githubusercontent.com/assets/640/10770784/857eb5d8-7cc3-11e5-8f4f-1ebdd6c91f83.png)

With the changes:
![screenshot 2015-10-27 15 54 01](https://cloud.githubusercontent.com/assets/640/10770771/78cddefe-7cc3-11e5-90be-16f9e0ac1034.png)

Removing this unneeded allocation made an easier time on the GC and was able to release more instances.