### PR TITLE
avoid stat.dev_major and other methods on windows

### DIFF
--- a/lib/filewatch/tail.rb
+++ b/lib/filewatch/tail.rb
@@ -229,7 +229,7 @@ module FileWatch
     private
     def _sincedb_write
       path = @opts[:sincedb_path]
-      if File.device?(path)
+      if @iswindows || File.device?(path)
         IO.write(path, serialize_sincedb, 0)
       else
         File.atomic_write(path) {|file| file.write(serialize_sincedb) }

--- a/lib/filewatch/watch.rb
+++ b/lib/filewatch/watch.rb
@@ -45,7 +45,7 @@ module FileWatch
     def inode(path,stat)
       if @iswindows
         fileId = Winhelper.GetWindowsUniqueFileIdentifier(path)
-        inode = [fileId, stat.dev_major, stat.dev_minor]
+        inode = [fileId, 0, 0] # dev_* doesn't make sense on Windows
       else
         inode = [stat.ino.to_s, stat.dev_major, stat.dev_minor]
       end


### PR DESCRIPTION
on windows avoid our File.atomic_write since it heavily uses stat functionality not available for this OS