### PR TITLE
Re-enable timeout when a file change is detected after we closed it

### DIFF
--- a/filewatch.gemspec
+++ b/filewatch.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.name = "filewatch"
-  spec.version = "0.7.0"
+  spec.version = "0.7.1"
   spec.summary = "filewatch - file watching for ruby"
   spec.description = "Watch files and directories in ruby. Also supports tailing and glob file patterns."
   spec.files = files


### PR DESCRIPTION
This fixes a bug that @ppf2 found