### PR TITLE
raise BufferFullError when @size_limit reached 

### DIFF
--- a/filewatch.gemspec
+++ b/filewatch.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.name = "filewatch"
-  spec.version = "0.8.1"
+  spec.version = "0.9.0"
   spec.summary = "filewatch - file watching for ruby"
   spec.description = "Watch files and directories in ruby. Also supports tailing and glob file patterns."
   spec.files = files

--- a/lib/filewatch/buftok.rb
+++ b/lib/filewatch/buftok.rb
@@ -30,6 +30,8 @@
 #  end
 
 module FileWatch; class BufferedTokenizer
+  class BufferFullError < StandardError; end
+                    
   # New BufferedTokenizers will operate on lines delimited by "\n" by default
   # or allow you to specify any delimiter token you so choose, which will then
   # be used by String#split to tokenize the input data
@@ -67,7 +69,7 @@ module FileWatch; class BufferedTokenizer
 
     # Check to see if the buffer has exceeded capacity, if we're imposing a limit
     if @size_limit
-      raise 'input buffer full' if @input_size + entities.first.size > @size_limit
+      raise BufferFullError, 'input buffer full' if @input_size + entities.first.size > @size_limit
       @input_size += entities.first.size
     end
     


### PR DESCRIPTION
This will provide better error messaging for client libraries which can catch this explicitly. This is in direct service of https://github.com/logstash-plugins/logstash-codec-json_lines/pull/30